### PR TITLE
Support PostgreSQL DB

### DIFF
--- a/app/ProophessorDo/Projection/User/UserFinder.php
+++ b/app/ProophessorDo/Projection/User/UserFinder.php
@@ -33,6 +33,11 @@ class UserFinder
         return $this->connection->fetchAll(sprintf('SELECT * FROM %s', Table::USER));
     }
 
+    /**
+     * @param string $userId
+     * @return null|\stdClass
+     * @throws \Doctrine\DBAL\DBALException
+     */
     public function findById(string $userId): ?\stdClass
     {
         $stmt = $this->connection->prepare(sprintf('SELECT * FROM %s WHERE id = :user_id', Table::USER));
@@ -48,6 +53,11 @@ class UserFinder
         return $result;
     }
 
+    /**
+     * @param string $emailAddress
+     * @return null|\stdClass
+     * @throws \Doctrine\DBAL\DBALException
+     */
     public function findOneByEmailAddress(string $emailAddress): ?\stdClass
     {
         $stmt = $this->connection->prepare(sprintf('SELECT * FROM %s WHERE email = :email LIMIT 1', Table::USER));
@@ -63,6 +73,11 @@ class UserFinder
         return $result;
     }
 
+    /**
+     * @param string $todoId
+     * @return null|\stdClass
+     * @throws \Doctrine\DBAL\DBALException
+     */
     public function findUserOfTodo(string $todoId): ?\stdClass
     {
         $stmt = $this->connection->prepare(sprintf(

--- a/app/Providers/ProophessorDoServiceProvider.php
+++ b/app/Providers/ProophessorDoServiceProvider.php
@@ -23,7 +23,7 @@ class ProophessorDoServiceProvider extends ServiceProvider
                 case 'mysql':
                     $driver = 'pdo_mysql';
                     break;
-                case 'postgres':
+                case 'pgsql':
                     $driver = 'pdo_pgsql';
             }
 


### PR DESCRIPTION
The current implementation does not support PostgreSQL because it creates the tables for the read models manually instead using the DBAL SchemaBuilder. Additionally it uses a wrong key for the database configuration.